### PR TITLE
Fixed map_uuid tag type

### DIFF
--- a/MapImageEngine/src/FaigerSYS/MapImageEngine/item/FilledMap.php
+++ b/MapImageEngine/src/FaigerSYS/MapImageEngine/item/FilledMap.php
@@ -56,7 +56,7 @@ class FilledMap extends Item {
 		}
 		
 		$tag = $this->getNamedTag();
-		$tag->setString('map_uuid', (string) $map_id, true);
+		$tag->setLong('map_uuid', $map_id, true);
 		parent::setNamedTag($tag);
 	}
 	


### PR DESCRIPTION
Was causing some issues with tag equality check, because client automatically converts StringTag to LongTag (thinking it's just a legacy format)