### PR TITLE
Fix check for image by replacing !is_resource($image) with $image === false

### DIFF
--- a/MIE_Converter/src/FaigerSYS/MIE_Converter/MIE_Converter.php
+++ b/MIE_Converter/src/FaigerSYS/MIE_Converter/MIE_Converter.php
@@ -60,7 +60,7 @@ class MIE_Converter extends PluginBase {
 		}
 		
 		$image = @imagecreatefromstring($data);
-		if (!is_resource($image)) {
+		if ($image === false) {
 			$sender->sendMessage(self::MSG_PREFIX . 'File is not an image, or image has unsupported by your GD library format! Convert image to supported format (e.g. PNG) and try again, or use online converter');
 			return true;
 		}

--- a/MIE_Converter/src/FaigerSYS/MIE_Converter/MapImageUtils.php
+++ b/MIE_Converter/src/FaigerSYS/MIE_Converter/MapImageUtils.php
@@ -12,7 +12,7 @@ class MapImageUtils {
 	const CURRENT_VERSION = 2;
 	
 	public static function generateImageData($image, int $blocks_width, int $blocks_height, int $compression_level = 0, int $resize_type = IMG_NEAREST_NEIGHBOUR, int $chunk_width = self::MAP_WIDTH, int $chunk_height = self::MAP_HEIGTH) {
-		if (!is_resource($image) || $blocks_width < 0 || $blocks_height < 0 || $chunk_width < 0 || $chunk_height < 0) {
+		if ($image === false || $blocks_width < 0 || $blocks_height < 0 || $chunk_width < 0 || $chunk_height < 0) {
 			return;
 		}
 		


### PR DESCRIPTION
The converter does not work on my server because the gd extension returns `GdImage` or `resource` from `imagecreatefromstring`. We should check for `false` to check if the image type is unsupported, the data is not in a recognised format, or the image is corrupt and cannot be loaded.